### PR TITLE
Handle deletion of non-existing and ADMIN users

### DIFF
--- a/src/main/java/com/journal/Journal/controller/AdminController.java
+++ b/src/main/java/com/journal/Journal/controller/AdminController.java
@@ -26,10 +26,19 @@ public class AdminController {
     //Delete User
     @DeleteMapping("/{userName}")
     public ResponseEntity<?> deleteUser(@PathVariable String userName){
-           if (userService.deleteByUserName(userName)){
-               return new ResponseEntity<>("User Deleted",HttpStatus.OK);
-           }
-        return new ResponseEntity<>("User Not found",HttpStatus.BAD_REQUEST);
+       
+        // Attempt to delete the user
+        if (userService.deleteByUserName(userName)) {
+            return new ResponseEntity<>("User Deleted", HttpStatus.OK);
+        }
+        
+        // Check the reason for failure
+        User user = userService.findByUserName(userName);
+        if (user == null) {
+            return new ResponseEntity<>("User Not Found", HttpStatus.NOT_FOUND);
+        }
+        
+        return new ResponseEntity<>("Cannot delete ADMIN user", HttpStatus.FORBIDDEN);
     }
 
 }

--- a/src/main/java/com/journal/Journal/service/UserService.java
+++ b/src/main/java/com/journal/Journal/service/UserService.java
@@ -52,7 +52,13 @@ public class UserService {
     }
 
     public boolean deleteByUserName(String userName) {
-        boolean hasAdminRole = userRepository.findByUserName(userName).getRoles().stream().anyMatch(role-> role.equals("ADMIN"));
+    	User user = userRepository.findByUserName(userName);
+    	
+    	if(user == null) {
+    		return false;
+    	}
+    	
+        boolean hasAdminRole = user.getRoles().stream().anyMatch(role-> role.equals("ADMIN"));
         if(!hasAdminRole){
             userRepository.findByUserName(userName).getJournalEntries().forEach(journalEntry -> journalEntryRepository.deleteById(journalEntry.getId()));
             userRepository.deleteByUserName(userName);


### PR DESCRIPTION
- Enhanced the user deletion functionality to handle cases where the user does not exist or is an ADMIN.
- Returns a `404 Not Found` status if the user does not exist.
- Returns a `403 Forbidden` status if an attempt is made to delete an ADMIN user.
