### PR TITLE
Enhance User Management: Global Exception Handling, Admin Role Assignment, and Role Transfer Enforcement

### DIFF
--- a/src/main/java/com/journal/Journal/controller/AdminController.java
+++ b/src/main/java/com/journal/Journal/controller/AdminController.java
@@ -1,15 +1,17 @@
 package com.journal.Journal.controller;
 
 import com.journal.Journal.dto.UserDTO;
-import com.journal.Journal.entity.User;
 import com.journal.Journal.service.UserService;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/admin")
@@ -26,19 +28,27 @@ public class AdminController {
     //Delete User
     @DeleteMapping("/{userName}")
     public ResponseEntity<?> deleteUser(@PathVariable String userName){
-       
-        // Attempt to delete the user
-        if (userService.deleteByUserName(userName)) {
-            return new ResponseEntity<>("User Deleted", HttpStatus.OK);
+        userService.deleteByUserName(userName);
+        return new ResponseEntity<>("User Deleted", HttpStatus.OK);
+    }
+    
+    //Assign Admin Role
+    @PostMapping("/assign-admin")
+    public ResponseEntity<?> transferAdminRole(@RequestBody Map<String, Object> requestBody) {
+    	Object newAdminUserNameObj = requestBody.get("newAdminUserName");
+    	
+    	// Check if the value is a String
+        if (!(newAdminUserNameObj instanceof String)) {
+            return new ResponseEntity<>("Invalid newAdminUserName", HttpStatus.BAD_REQUEST);
         }
-        
-        // Check the reason for failure
-        User user = userService.findByUserName(userName);
-        if (user == null) {
-            return new ResponseEntity<>("User Not Found", HttpStatus.NOT_FOUND);
-        }
-        
-        return new ResponseEntity<>("Cannot delete ADMIN user", HttpStatus.FORBIDDEN);
+    	
+        String newAdminUserName = (String) newAdminUserNameObj; 
+    	Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    	
+    	if(userService.assignAdminRole(authentication.getName(), newAdminUserName)) {
+            return new ResponseEntity<>("Admin role assigned successfully", HttpStatus.OK);
+    	}
+    	return new ResponseEntity<>("The user " + newAdminUserName + " is already an admin.", HttpStatus.CONFLICT);
     }
 
 }

--- a/src/main/java/com/journal/Journal/controller/UserController.java
+++ b/src/main/java/com/journal/Journal/controller/UserController.java
@@ -36,10 +36,8 @@ public class UserController {
     @DeleteMapping
     public ResponseEntity<?> deleteUser(){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (userService.deleteByUserName(authentication.getName())){
-            return new ResponseEntity<>("User Deleted",HttpStatus.OK);
-        }
-        return new ResponseEntity<>("User Not found",HttpStatus.NOT_FOUND);
+        userService.deleteByUserName(authentication.getName());
+        return new ResponseEntity<>("User Deleted",HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/journal/Journal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/journal/Journal/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.journal.Journal.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(UserNotFoundException.class)
+	public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException exception) {
+		return new ResponseEntity<>(exception.getMessage() ,HttpStatus.NOT_FOUND);
+	}
+	
+	@ExceptionHandler(RoleTransferRequiredException .class)
+	public ResponseEntity<String> handleRoleTransferRequiredException(RoleTransferRequiredException exception) {
+		return new ResponseEntity<>(exception.getMessage() ,HttpStatus.CONFLICT);
+	}
+	
+}

--- a/src/main/java/com/journal/Journal/exception/RoleTransferRequiredException.java
+++ b/src/main/java/com/journal/Journal/exception/RoleTransferRequiredException.java
@@ -1,0 +1,7 @@
+package com.journal.Journal.exception;
+
+public class RoleTransferRequiredException extends RuntimeException{
+	public RoleTransferRequiredException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/journal/Journal/exception/UserNotFoundException.java
+++ b/src/main/java/com/journal/Journal/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.journal.Journal.exception;
+
+public class UserNotFoundException extends RuntimeException{
+	public UserNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/journal/Journal/repository/UserRepository.java
+++ b/src/main/java/com/journal/Journal/repository/UserRepository.java
@@ -1,10 +1,11 @@
 package com.journal.Journal.repository;
-import com.journal.Journal.entity.User;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import com.journal.Journal.entity.User;
 
 public interface UserRepository extends MongoRepository<User, ObjectId> {
     User findByUserName(String username);
     void deleteByUserName(String username);
+    long countByRoles(String role);
 }


### PR DESCRIPTION
This pull request includes several enhancements:

1. **Global Exception Handling:**
   - Added a `GlobalExceptionHandler` to handle `UserNotFoundException` and `RoleTransferRequiredException` exceptions globally.

2. **Admin Role Assignment:**
   - Introduced a new `/admin/assign-role` endpoint to allow current admins to assign the admin role to other users. 
   -   `POST /admin/assign-role` endpoint requires a JSON payload with the `newAdminUserName` to assign admin rights to a specified user.

3. **Role Transfer Enforcement for User Deletion:**
   -  Updated the `deleteByUserName` method in the `UserService` class to enforce role transfer if the user being deleted is the last remaining admin. This ensures that there is always at least one admin in the system.
   - Throws a `RoleTransferRequiredException` if only one admin exists, requiring a role transfer before deletion.

**Additional Changes:**
- Updated `UserRepository` with a new method for counting users with a specific role.

If there are any improvements or additional considerations, please let me know. Thank you!